### PR TITLE
no spaces around assignment of default variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,11 +114,11 @@ Additional recommendations:
 
     - assignment: `=`
 
-        - _Note that this also applies when indicating default parameter value(s) in a function declaration_
+        - Exception in the case of default arguments:
 
            ```coffeescript
-           test: (param = null) -> # Yes
-           test: (param=null) -> # No
+           test: (param = null) -> # No
+           test: (param=null) -> # Yes
            ```
 
     - augmented assignment: `+=`, `-=`, etc.


### PR DESCRIPTION
I have no other argument besides I'm more used to this style and I see it like this in Python a lot
