### PR TITLE
remove note about standalone @

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,11 +436,14 @@ Array::slice # Yes
 Array.prototype.slice # No
 ```
 
-Prefer `@property` over `this.property`.
+Prefer `@` over `this`.
 
 ```coffeescript
 return @property # Yes
 return this.property # No
+
+return @ # Yes
+return this # No
 ```
 
 Avoid `return` where not required, unless the explicit return increases clarity.


### PR DESCRIPTION
We've never obeyed this in our code and I see no reason to start now. Obeying it leads to inconsistent code, anyway, where sometimes you use @ for this and sometimes you don't.
