### PR TITLE
Revert "no spaces around assignment of default variables"

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,11 +114,11 @@ Additional recommendations:
 
     - assignment: `=`
 
-        - Exception in the case of default arguments:
+        - _Note that this also applies when indicating default parameter value(s) in a function declaration_
 
            ```coffeescript
-           test: (param = null) -> # No
-           test: (param=null) -> # Yes
+           test: (param = null) -> # Yes
+           test: (param=null) -> # No
            ```
 
     - augmented assignment: `+=`, `-=`, etc.


### PR DESCRIPTION
This reverts commit 17effb74bbceb6d8505efa6657d03e86ede003a1.
