### PR TITLE
Enabled `evil` option for coffeehint

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -32,8 +32,8 @@ for file in $files; do
   $coffeelint -f $dir'coffeelint-config.json' $file ; update_exit $? 0
 
   # coffee-jshint
-  echo $file | egrep '^test/' | xargs $coffeejshint -o node --globals it,describe,before,beforeEach,after,afterEach ; update_exit $? 0
-  echo $file | egrep -v '^test/' | xargs $coffeejshint -o node ; update_exit $? 0
+  echo $file | egrep '^test/' | xargs $coffeejshint -o node,mocha,evil ; update_exit $? 0
+  echo $file | egrep -v '^test/' | xargs $coffeejshint -o node,evil ; update_exit $? 0
 
   # it.only, describe.only etc in test
   line=`echo $file | egrep '^test/' | xargs egrep -nv '^ *#' | egrep \(it\|describe\).\(only\|skip\)`


### PR DESCRIPTION
Jshint doesn't let you have functions called `eval` - even if they're methods not the function global. This causes issues, for example with https://github.com/mranney/node_redis.

You can disable this by using the `evil` option which disabled checking for eval. 

Also simplified the test hinting by using the `mocha` option instead of explicitly defining the mocha globals. 

Tested locally. 